### PR TITLE
Fix `join` directive

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ function plugin(opts){
       var codes = [], c
       while (c = SHORTCODE_RE.exec(str)) codes.push(c[1]);
       codes.forEach( function(code){
-        var tmpl = metalsmith.join(dir, code + ".jade")
+        var tmpl = join(dir, code + ".jade")
         // if (shortcodes._shortcodes[code]) return;  // need shortcodes.has() 
         debug('found shortcode: %s', code);
         try {


### PR DESCRIPTION
Fix error thrown by using 'join' as a method of the metalsmith object, rather than as an object itself
