### PR TITLE
Use Consolidate rather than jade

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ function plugin(opts){
           return;
         }
         shortcodes.add(code, function(buf,attrs,extra){
-          var obj = extend({}, extra, attrs, {innerText: buf.toString()});
+          var obj = extend({}, extra, attrs, metalsmith.metadata(), {innerText: buf.toString()});
           return jade.renderFile(tmpl, obj);
         })
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var jade = require('jade');
+var consolidate = require('consolidate');
 var shortcodes = require('shortcode-parser');
 var debug = require('debug')('metalsmith-shortcodes');
 var each = require('async').each;
 var extend = require('extend');
+var omit = require('lodash.omit');
 var join = require('path').join;
 var match = require('multimatch');
 var fs = require('fs');
@@ -40,8 +41,19 @@ var SHORTCODE_RE = /\[\s*([^\/][A-Za-z0-9\-_]*)/g
 function plugin(opts){
   opts = opts || {};
 
+  var settings = [
+    'directory',
+    'pattern',
+    'engine',
+    'ext'
+  ];
+
   var dir = opts.directory || 'templates';
   var pattern = opts.pattern;
+  var engine = opts.engine || 'jade';
+  var ext = opts.extension || '.jade';
+
+  var consolidateParams = omit(opts, settings);
 
   return function(files, metalsmith, done){
 
@@ -71,7 +83,7 @@ function plugin(opts){
       var codes = [], c
       while (c = SHORTCODE_RE.exec(str)) codes.push(c[1]);
       codes.forEach( function(code){
-        var tmpl = join(dir, code + ".jade")
+        var tmpl = join(dir, code + ext)
         // if (shortcodes._shortcodes[code]) return;  // need shortcodes.has() 
         debug('found shortcode: %s', code);
         try {
@@ -81,8 +93,20 @@ function plugin(opts){
           return;
         }
         shortcodes.add(code, function(buf,attrs,extra){
-          var obj = extend({}, extra, attrs, metalsmith.metadata(), {innerText: buf.toString()});
-          return jade.renderFile(tmpl, obj);
+          var obj = extend({}, extra, attrs, consolidateParams, metalsmith.metadata(), {innerText: buf.toString()});
+          // very dodgy code to force synchronous execution for consolidate
+          var ret;
+          consolidate[engine](tmpl, obj, function(err, html){
+            if (err) {
+              ret = false;
+              throw err;
+            }
+            ret = html;
+          });
+          while(ret === undefined) {
+            // do nothing
+          }
+          return ret;
         })
       });
       return codes;

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ function plugin(opts){
       var codes = [], c
       while (c = SHORTCODE_RE.exec(str)) codes.push(c[1]);
       codes.forEach( function(code){
-        var tmpl = metalsmith.join(dir, code + ".jade")
+        var tmpl = join(dir, code + ".jade")
         // if (shortcodes._shortcodes[code]) return;  // need shortcodes.has() 
         debug('found shortcode: %s', code);
         try {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metalsmith-shortcodes",
   "description": "A metalsmith plugin to render wordpress-esque shortcodes via templates.",
   "repository": "git://github.com/ericgj/metalsmith-shortcodes.git",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "author": "Eric Gjertsen",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -7,16 +7,18 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
-    "jade": "~1.3.0", 
-    "shortcode-parser": "0.0.1",
-    "async": "~0.2.10",
-    "debug": "~0.7.4",
-    "extend": "~1.2.1",
-    "multimatch": "^0.1.0"
+    "async": "~2.0.0",
+    "consolidate": "^0.14.1",
+    "debug": "~2.2.0",
+    "extend": "~3.0.0",
+    "lodash.omit": "^4.3.0",
+    "multimatch": "^2.1.0",
+    "shortcode-parser": "0.0.1"
   },
   "devDependencies": {
-    "mocha": "1.x",
-    "metalsmith": "0.x",
-    "assert-dir-equal": "0.0.1"
+    "assert-dir-equal": "1.0.1",
+    "jade": "^1.11.0",
+    "metalsmith": "2.x",
+    "mocha": "2.x"
   }
 }


### PR DESCRIPTION
I've refactored to use [Consolidate.js](https://github.com/tj/consolidate.js). The plugin now takes an engine and ext parameter (defaulting to `jade` and `.jade` respectively. 

This is important for my use case, because it means I can use the same version of Jade/Pug for both `metalsmith-shortcodes` and `metalsmith-layouts`, but presumably this is useful for those using different templating languages.

This also shifts Jade to `devDependencies` (so the tests still run), so if you're using this in another project you need to ensure you've got the engine installed
